### PR TITLE
fix: support multiline typedefs when extending a type

### DIFF
--- a/src/features/extendTypes.js
+++ b/src/features/extendTypes.js
@@ -79,7 +79,7 @@ class ExtendTypes {
    * @ignore
    */
   _getCommentWithPropertiesInfo(comment) {
-    const [, name] = /@typedef\s+\{[^\}]+\}\s*(.*?)\s/i.exec(comment);
+    const [, name] = /@typedef\s+\{[^\}]+\}[\s\*]*(.*?)\s/i.exec(comment);
     const [, augments] = /@(?:augments|extends)\s+(.*?)\s/i.exec(comment);
     const allLines = comment.split('\n');
     const linesCount = allLines.length;
@@ -164,7 +164,11 @@ class ExtendTypes {
     return this._commentsWithIntersections.reduce(
       (acc, comment) => {
         // Extract the `typedef` types and name.
-        const [typedefLine, rawTypes, name] = /@typedef\s*\{([^\}]+)\}\s*(.*?)\s/i.exec(comment);
+        const [
+          typedefLine,
+          rawTypes,
+          name,
+        ] = /@typedef\s*\{([^\}]+)\}[\s\*]*(.*?)\s/i.exec(comment);
         // Transform the types into an array.
         const types = rawTypes
         .split('&')


### PR DESCRIPTION
### What does this PR do?

Due to the regular expressions on the "extend type" feature, the following syntax was being replaced with union instead of extending the base type:

```js
/**
 * @typedef {StaticsControllerOptions & StaticsControllerWrapperOptionsProperties}
 * StaticsControllerWrapperOptions
 * @parent module:controllers/common
 */

/**
 * @typedef {Object} StaticsControllerWrapperOptionsProperties
 * @property {StaticsControllerMiddlewaresFn} middlewares ...
 * @augments StaticsControllerWrapperOptions
 * @parent module:controllers/common
 */
```

This PR changes the expression so it will allow a line break before the name.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```