### PR TITLE
fix: do not require newline for parsed comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const features = require('./features');
  * @ignore
  */
 const traverseComments = (source, fn) => {
-  const regex = /\/\*\*\s*\n(?:[^\*]|\*[^\/])*\*\//g;
+  const regex = /\/\*\*\s*(?:[^\*]|\*[^\/])*\*\//g;
   let match = regex.exec(source);
   while (match) {
     const [comment] = match;


### PR DESCRIPTION
### What does this PR do?

Address #31 and support single line JSDoc comment parsing by removing newline requirement.

### How should it be tested manually?

Create the same minimum reproducible example in the issue, include the files into the jsdoc configuration, and then run

```bash
yarn docs
# or
npm docs
```